### PR TITLE
Replace libcheck by cgreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,7 +175,7 @@ libtool
 src/stamp-h1
 libtopdax.a
 topdax
-topdax_test
+topdax_suite
 test-driver
 *.trs
 *.gcno

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,10 +13,10 @@ topdax_SOURCES = src/entry.c
 topdax_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 topdax_LDADD = libtopdax.a $(CODE_COVERAGE_LIBS)
 
-if HAVE_CHECK
-TESTS = topdax_test
-check_PROGRAMS = topdax_test
-topdax_test_SOURCES = tests/topdax_suite.c
-topdax_test_CFLAGS = $(CHECK_CFLAGS) $(CODE_COVERAGE_CFLAGS)
-topdax_test_LDADD = libtopdax.a $(CHECK_LIBS) $(CODE_COVERAGE_LIBS)
+if HAVE_CGREEN
+TESTS = topdax_suite
+check_PROGRAMS = topdax_suite
+topdax_suite_SOURCES = tests/topdax_suite.c
+topdax_suite_CFLAGS = $(CGREEN_CFLAGS) $(CODE_COVERAGE_CFLAGS)
+topdax_suite_LDADD = libtopdax.a $(CGREEN_LIBS) $(CODE_COVERAGE_LIBS)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -19,18 +19,18 @@ PKG_PROG_PKG_CONFIG
 
 AX_CODE_COVERAGE
 AC_ARG_WITH([unit-tests],
-    AS_HELP_STRING([--without-unit-tests], [Ignore presence of check and disable unit tests]))
+    AS_HELP_STRING([--without-unit-tests], [Ignore presence of cgreen and disable unit tests]))
 
 AS_IF([test "x$with_unit_tests" != "xno"],
-      [PKG_CHECK_MODULES([CHECK], [check >= 0.9.8], [have_check=yes], [have_check=no])],
-      [have_check=no])
+      [PKG_CHECK_MODULES([CGREEN], [cgreen >= 1.0.0], [have_cgreen=yes], [have_cgreen=no])],
+      [have_cgreen=no])
 
-AS_IF([test "x$have_check" != "xyes"],
+AS_IF([test "x$have_cgreen" != "xyes"],
       [AS_IF([test "x$with_unit_tests" = "xyes"],
-             [AC_MSG_ERROR([unit tests requested but libcheck not found])])
+             [AC_MSG_ERROR([unit tests requested but libcgreen not found])])
 ])
 
-AM_CONDITIONAL([HAVE_CHECK], [test "x$have_check" != "xno"])
+AM_CONDITIONAL([HAVE_CGREEN], [test "x$have_cgreen" != "xno"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/topdax.c
+++ b/src/topdax.c
@@ -57,8 +57,8 @@ int topdax_run(int argc, char **argv)
 	struct arguments args = {
 		.verbose = false,
 	};
-	error_t parse_err = argp_parse(&argp, argc, argv, 0, NULL, &args);
-	if (parse_err)
+	error_t err = argp_parse(&argp, argc, argv, ARGP_NO_EXIT, NULL, &args);
+	if (err)
 		return EXIT_FAILURE;
 
 	return EXIT_SUCCESS;

--- a/tests/topdax_suite.c
+++ b/tests/topdax_suite.c
@@ -6,39 +6,42 @@
 #include "config.h"
 #endif
 
-#include <check.h>
+#include <cgreen/cgreen.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include "topdax/topdax.h"
 
-START_TEST(test_verbose_flag)
+Describe(topdax);
+BeforeEach(topdax)
+{
+}
+
+AfterEach(topdax)
+{
+}
+
+Ensure(topdax, verbose_flag)
 {
 	char *argv[] = { "./topdax", "--verbose", NULL };
-	ck_assert_int_eq(topdax_run(2, &argv[0]), EXIT_SUCCESS);
+	int exit_code = topdax_run(2, &argv[0]);
+	assert_that(exit_code, is_equal_to(EXIT_SUCCESS));
 }
-END_TEST
 
-START_TEST(test_unsupported_flag)
+Ensure(topdax, unsupported_flag)
 {
 	char *argv[] = { "./topdax", "--unsupported", NULL };
-	/* Do not print anything on assert */
+	/** Suppress stderr */
 	close(2);
-	topdax_run(2, &argv[0]);
+	int exit_code = topdax_run(2, &argv[0]);
+	assert_that(exit_code, is_equal_to(EXIT_FAILURE));
 }
-END_TEST
 
-int main(void)
+int main(int argc, char **argv)
 {
-	Suite *suite = suite_create("topdax");
-
-	TCase *tc_core = tcase_create("Core");
-	tcase_add_exit_test(tc_core, test_unsupported_flag, 64);
-	tcase_add_test(tc_core, test_verbose_flag);
-	suite_add_tcase(suite, tc_core);
-
-	SRunner *sr = srunner_create(suite);
-	srunner_run_all(sr, CK_ENV);
-	int number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
-	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	(void)(argc);
+	(void)(argv);
+	TestSuite *suite = create_test_suite();
+	add_test_with_context(suite, topdax, unsupported_flag);
+	add_test_with_context(suite, topdax, verbose_flag);
+	return run_test_suite(suite, create_text_reporter());
 }


### PR DESCRIPTION
A __configure__ script finds linker and compiler flags of __cgreen__ package
using __pkg-config__ tool, but right now __cgreen__ has no
__*.pc__ file in the distribution. So to enable unit tests, you
must manually create __cgreen.pc__ file on your computer.

Closes #14.