### PR TITLE
Use standard Autoconf checks instead of pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,24 +11,24 @@ libtopdax_a_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 noinst_LIBRARIES += libapplication.a
 libapplication_a_SOURCES = include/topdax/application.h
 libapplication_a_SOURCES += src/glfw_application.c
-libapplication_a_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(GLFW_CFLAGS)
+libapplication_a_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 
 bin_PROGRAMS = topdax
 topdax_SOURCES = src/entry.c
-topdax_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(GLFW_CFLAGS)
-topdax_LDADD = libtopdax.a libapplication.a $(CODE_COVERAGE_LIBS) $(GLFW_LIBS)
+topdax_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+topdax_LDADD = libtopdax.a libapplication.a $(CODE_COVERAGE_LIBS)
 
 if HAVE_CGREEN
 TESTS = topdax_suite
 check_PROGRAMS = topdax_suite
 topdax_suite_SOURCES = tests/topdax_suite.c
-topdax_suite_CFLAGS = $(CGREEN_CFLAGS) $(CODE_COVERAGE_CFLAGS) $(GLFW_CFLAGS)
-topdax_suite_LDADD = libtopdax.a $(CGREEN_LIBS) $(CODE_COVERAGE_LIBS)
+topdax_suite_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+topdax_suite_LDADD = libtopdax.a -lcgreen $(CODE_COVERAGE_LIBS)
 
 TESTS += glfw_suite
 check_PROGRAMS += glfw_suite
 glfw_suite_SOURCES = tests/glfw_suite.c
-glfw_suite_CFLAGS = $(CGREEN_CFLAGS) $(CODE_COVERAGE_CFLAGS) $(GLFW_CFLAGS)
-glfw_suite_LDADD = libapplication.a $(CGREEN_LIBS) $(CODE_COVERAGE_LIBS)
+glfw_suite_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+glfw_suite_LDADD = libapplication.a -lcgreen $(CODE_COVERAGE_LIBS)
 glfw_suite_LDFLAGS = -Wl,--wrap=argp_parse
 endif

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 Install topdax from sources, by running:
 
 ```sh
-$ apt install gcc autoconf pkg-config libglfw3-dev
+$ apt install gcc autoconf libglfw3-dev
 $ git clone https://github.com/souryogurt/topdax.git
 $ cd topdax
 $ autoreconf -i

--- a/configure.ac
+++ b/configure.ac
@@ -11,14 +11,13 @@ AM_PROG_AR
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_RANLIB
-PKG_PROG_PKG_CONFIG
 
-# Checks for header files.
-
-# Checks for typedefs, structures, and compiler characteristics.
-
-PKG_CHECK_MODULES([GLFW], [glfw3 >= 3.2.1])
-
+AC_CHECK_HEADER([GLFW/glfw3.h], [], [
+  AC_MSG_ERROR([GLFW/glfw3.h not found])
+])
+AC_CHECK_LIB([glfw], [glfwInit], [], [
+  AC_MSG_ERROR([libglfw not found])
+])
 AC_DEFINE([TOPDAX_USE_PLATFORM_GLFW], [1], [Use GLFW for application and window])
 
 AX_CODE_COVERAGE
@@ -26,14 +25,15 @@ AC_ARG_WITH([unit-tests],
     AS_HELP_STRING([--without-unit-tests], [Ignore presence of cgreen and disable unit tests]))
 
 AS_IF([test "x$with_unit_tests" != "xno"],
-      [PKG_CHECK_MODULES([CGREEN], [cgreen >= 1.0.0], [have_cgreen=yes], [have_cgreen=no])],
+      [AC_CHECK_HEADER([cgreen/cgreen.h],
+       [AC_CHECK_LIB([cgreen], [run_test_suite], [have_cgreen=yes], [have_cgreen=no])],
+       [have_cgreen=no])],
       [have_cgreen=no])
 
 AS_IF([test "x$have_cgreen" != "xyes"],
       [AS_IF([test "x$with_unit_tests" = "xyes"],
-             [AC_MSG_ERROR([unit tests requested but libcgreen not found])])
+             [AC_MSG_ERROR([unit tests requested but cgreen/cgreen.h not found])])
 ])
-
 AM_CONDITIONAL([HAVE_CGREEN], [test "x$have_cgreen" != "xno"])
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
This pull request replaces `PKG_CHECK_MODULES` macro by standard `Autoconf` checks.
Please note, that it does not check the version of `libglfw3`. Previous macro checks that `glfw3 >=3.2.1` to be sure that `libglfw3` contains Vulkan support. 
The current version of `topdax` do not use Vulkan, so this test not required. When in the future we will use `glfw3` Vulkan support, it is better to add tests for particular typedefs or functions in the library instead of checking for required version of the library itself.